### PR TITLE
Join AMENT_PREFIX_PATH by colon

### DIFF
--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -85,8 +85,9 @@ ${_xacro_err}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}" "${PROJECT_BUILD_INDEX}/share/${PROJECT_NAME}")
 
   ## command to actually call xacro
-  add_custom_command(OUTPUT ${output}
-    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
+  list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV)
+  add_custom_command(OUTPUT ${abs_output}
+    COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH_ENV}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
     DEPENDS ${input} ${_xacro_deps_result} ${_XACRO_DEPENDS}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMENT "xacro: generating ${output} from ${input}"

--- a/cmake/xacro-extras.cmake
+++ b/cmake/xacro-extras.cmake
@@ -85,7 +85,7 @@ ${_xacro_err}")
   execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink "${PROJECT_SOURCE_DIR}" "${PROJECT_BUILD_INDEX}/share/${PROJECT_NAME}")
 
   ## command to actually call xacro
-  list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV)
+  list(JOIN AMENT_PREFIX_PATH ":" AMENT_PREFIX_PATH_ENV) # format as colon-separated list
   add_custom_command(OUTPUT ${abs_output}
     COMMAND ${CMAKE_COMMAND} -E env AMENT_PREFIX_PATH="${PROJECT_BUILD_INDEX}:${AMENT_PREFIX_PATH_ENV}" xacro -o ${abs_output} ${input} ${_XACRO_REMAP}
     DEPENDS ${input} ${_xacro_deps_result} ${_XACRO_DEPENDS}


### PR DESCRIPTION
As the `AMENT_PREFIX_PATH` is a cmake list (it will be casted to a space separated string), it needs to be translated into the colon-separated string.